### PR TITLE
Upgrade Bourbon version from 2.1.0 to 3.1.8

### DIFF
--- a/lib/middleman-bourbon.rb
+++ b/lib/middleman-bourbon.rb
@@ -10,8 +10,6 @@ module MiddlemanBourbon
 
       # add bourbon to sass load path
       Sass.load_paths << File.expand_path("./app/assets/stylesheets", gem_dir)
-
-      puts "Bourbon loaded"
     end
     alias :included :registered
   end

--- a/middleman-bourbon.gemspec
+++ b/middleman-bourbon.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = MiddlemanBourbon::VERSION
 
-  gem.add_dependency 'bourbon', '>= 2.1.0'
+  gem.add_dependency 'bourbon', '>= 3.1.8'
 end


### PR DESCRIPTION
Hey there,

Looks like the version of Bourbon that is being passed along here is pretty old. This PR upgrades Bourbon from `2.1.0` to `3.1.8`.

It also removes the `puts` logging when the extension is loaded in. Seems unnecessary.

Thanks!
